### PR TITLE
This is noarch

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,7 +27,7 @@ pipeline {
         stage("Publish") {
             steps {
                 script {
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", arch: "x86_64", os: "noos", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", arch: "noarch", os: "noos", isStable: env.IS_STABLE)
                     publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", os: "noos", isStable: env.IS_STABLE)
                 }
             }

--- a/smart-mon.spec
+++ b/smart-mon.spec
@@ -14,8 +14,7 @@ Version: %(cat .version)
 Release: %(echo ${BUILD_METADATA})
 Source: %{name}-%{version}.tar.bz2
 
-# Compiling not currently required:
-# BuildArchitectures: noarch
+BuildArch: noarch
 
 Requires: jq
 Requires: python3-boto3


### PR DESCRIPTION
By default it's coming up as x86_64, but it's really noarch.

I left the version the same so we could just cleanup the 1.0.2-1.x86_64 editions once this merged.
